### PR TITLE
Fix Google Play warning outdated SDK

### DIFF
--- a/Editor/Dependencies.xml
+++ b/Editor/Dependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.google.android.play:app-update:2.0.0"/>
+        <androidPackage spec="com.google.android.play:app-update:2.1.0"/>
     </androidPackages>
 </dependencies>
 


### PR DESCRIPTION
Google Play will warn about [outdated SDK](https://developer.android.com/guide/playcore#playcore-migration) when submitting.

```
com.google.android.play:app-update has added this note for app-update:2.0.0:

If your app is targeting SDK 34+ (targetSdkVersion), then the PlayCore SDK is outdated and will likely cause crashes in your app! Please update: https://developer.android.com/guide/playcore#playcore-migration
```

This simply update the library to `2.1.0`